### PR TITLE
Dev/thread jni attach

### DIFF
--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -1,7 +1,6 @@
 #ifndef IL2CPP_UTILS_H
 #define IL2CPP_UTILS_H
 
-#include <jni.h>
 #pragma pack(push)
 
 #include <stdio.h>
@@ -10,7 +9,7 @@
 #include <optional>
 #include <vector>
 #include <unordered_map>
-
+#include <jni.h>
 
 #include "gc-alloc.hpp"
 

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -1,6 +1,7 @@
 #ifndef IL2CPP_UTILS_H
 #define IL2CPP_UTILS_H
 
+#include <jni.h>
 #pragma pack(push)
 
 #include <stdio.h>
@@ -8,6 +9,8 @@
 #include <dlfcn.h>
 #include <optional>
 #include <vector>
+#include <unordered_map>
+
 
 #include "gc-alloc.hpp"
 
@@ -692,7 +695,22 @@ namespace il2cpp_utils {
     }
 
     struct il2cpp_aware_thread : public std::thread {
+        private:
+            /// @brief clears the current threads jni env in the envs map
+            static void clear_current_jnienv();
+
+            /// @brief sets the current threads jni env in the envs map
+            static void set_current_jnienv(JNIEnv* env);
+
         public:
+            static inline std::string current_thread_id() {
+                std::stringstream thread_id; thread_id << std::this_thread::get_id();
+                return thread_id.str();
+            }
+
+            /// @brief allows users of il2cpp_aware_thread to get the jni env for the thread they are currently on, only works for actual il2cpp_aware_thread! not for mainthread or regular std::thread!
+            /// @return JNIEnv* as bound in internal_thread, or null if not available
+            static JNIEnv* get_current_jnienv();
 
             /// @brief method executed by the thread created in il2cpp_aware_thread
             /// @param pred the predicate to use in the thread
@@ -700,9 +718,17 @@ namespace il2cpp_utils {
             template<typename Predicate, typename... TArgs>
             requires(std::is_invocable_v<Predicate, std::decay_t<TArgs>...>)
             static void internal_thread(Predicate&& pred, TArgs&&... args) {
+                std::string loggerContext("internal_thread_" + current_thread_id());
+                auto logger = getLogger().WithContext(loggerContext); // logger is per thread id, can't be static
+
+                // attach thread to jvm
+                // TODO: provide jni env in some sort of map from thread id -> jni env?
+                auto jvm = get_modloader_jvm();
+                JNIEnv* env = nullptr;
+                jvm->AttachCurrentThread(&env, nullptr);
+                set_current_jnienv(env);
+
                 il2cpp_functions::Init();
-                std::stringstream loggerContext; loggerContext << "internal_thread_" << std::this_thread::get_id();
-                auto logger = getLogger().WithContext(loggerContext.str()); // logger is per thread id, can't be static
 
                 logger.info("Attaching thread");
                 auto domain = il2cpp_functions::domain_get();
@@ -733,7 +759,11 @@ namespace il2cpp_utils {
                 }
 
                 logger.info("Detaching thread");
+                clear_current_jnienv();
+                // detach il2cpp thread
                 il2cpp_functions::thread_detach(thread);
+                // detach thread from jvm
+                jvm->DetachCurrentThread();
             }
 
             /// @brief creates a thread that automatically will register with il2cpp and deregister once it exits, ensure your args live longer than the thread if they're by reference!

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -713,8 +713,7 @@ namespace il2cpp_utils {
                 auto logger = getLogger().WithContext("internal_thread_" + current_thread_id());
 
                 // attach thread to jvm
-                auto jvm = get_modloader_jvm();
-                jvm->AttachCurrentThread(&env, nullptr);
+                modloader_jvm->AttachCurrentThread(&env, nullptr);
 
                 il2cpp_functions::Init();
 
@@ -752,7 +751,7 @@ namespace il2cpp_utils {
                 il2cpp_functions::thread_detach(thread);
 
                 // detach thread from jvm
-                jvm->DetachCurrentThread();
+                modloader_jvm->DetachCurrentThread();
                 env = nullptr;
             }
 

--- a/src/tests/thread-tests.cpp
+++ b/src/tests/thread-tests.cpp
@@ -49,7 +49,7 @@ void test_thread() {
     IL2CPP_THREAD_TEST([](int v){}, 10);
 
     // pass rvalue into lvalue
-    // IL2CPP_THREAD_TEST([]( int& v){}, 10); // should not work
+    // IL2CPP_THREAD_TEST([](int& v){}, 10); // should not work
     // pass rvalue into rvalue
     IL2CPP_THREAD_TEST([](int&& v){}, 10); // should work
     // pass lvalue into lvalue
@@ -73,6 +73,14 @@ void test_thread() {
 
     ThreadTest tt;
     tt.test_thread();
+
+    il2cpp_utils::il2cpp_aware_thread([]{
+        // getting current jni env since we are attached
+        auto env = il2cpp_utils::il2cpp_aware_thread::get_current_env();
+
+        // getting current thread id as a test
+        auto id = il2cpp_utils::il2cpp_aware_thread::current_thread_id();
+    }).join();
 }
 
 void ThreadTest::test_thread() {

--- a/src/utils/il2cpp-utils.cpp
+++ b/src/utils/il2cpp-utils.cpp
@@ -298,23 +298,4 @@ namespace il2cpp_utils {
     void AddAllocatedDelegate(std::pair<Il2CppMethodPointer, bool> delegate, MethodInfo* mptr) {
         delegateMethodInfoMap.insert({delegate, mptr});
     }
-
-    // stores jni envs for threads
-    static std::unordered_map<std::string, JNIEnv*> il2cpp_aware_thread_envs;
-
-    void il2cpp_aware_thread::clear_current_jnienv() {
-        il2cpp_aware_thread_envs.erase(current_thread_id());
-    }
-
-    void il2cpp_aware_thread::set_current_jnienv(JNIEnv* env) {
-        il2cpp_aware_thread_envs[current_thread_id()] = env;
-    }
-
-    /// @brief allows users of il2cpp_aware_thread to get the jni env for the thread they are currently on, only works for actual il2cpp_aware_thread! not for mainthread or regular std::thread!
-    /// @return JNIEnv* as bound in internal_thread, or null if not available
-    JNIEnv* il2cpp_aware_thread::get_current_jnienv() {
-        auto itr = il2cpp_aware_thread_envs.find(current_thread_id());
-        if (itr == il2cpp_aware_thread_envs.end()) return nullptr;
-        return itr->second;
-    }
 }

--- a/src/utils/il2cpp-utils.cpp
+++ b/src/utils/il2cpp-utils.cpp
@@ -3,7 +3,6 @@
 #include "shared/utils/gc-alloc.hpp"
 #include "../../shared/utils/hashing.hpp"
 #include "../../shared/utils/il2cpp-utils.hpp"
-#include <jni.h>
 #include "../../shared/utils/utils.h"
 #include "../../shared/utils/il2cpp-functions.hpp"
 #include <algorithm>


### PR DESCRIPTION
Attaches il2cpp_aware_thread to jni as well as just il2cpp, and allows modders to access the created jnienv through a static utility method on il2cpp_aware_thread

idea for adding this originally by @hardcpp